### PR TITLE
New startup behavior.

### DIFF
--- a/src/cx/cxspec/locate.go
+++ b/src/cx/cxspec/locate.go
@@ -1,0 +1,96 @@
+package cxspec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+// LocPrefix determines the location type of the location string.
+type LocPrefix string
+
+// Locations types.
+const (
+	FileLoc    = LocPrefix("file")
+	TrackerLoc = LocPrefix("tracker")
+)
+
+// Constants.
+const (
+	defaultChainSpecFile = "./skycoin.chain_spec.json"
+)
+
+// Possible errors when executing 'Locate'.
+var (
+	ErrEmptySpec = errors.New("empty chain spec provided")
+	ErrInvalidLocPrefix = errors.New("invalid spec location prefix")
+)
+
+// Locate locates the chain spec given a 'loc' string.
+// The 'loc' string is to be of format '<location-prefix>:<location>'.
+// * <location-prefix> is 'tracker' if undefined.
+// * <location> either specifies the cx chain's genesis hash (if
+// <location-prefix> is 'tracker') or filepath of the spec file (if
+// <location-prefix> is 'file').
+func Locate(ctx context.Context, tracker *CXTrackerClient, loc string) (ChainSpec, error) {
+	prefix, suffix, err := splitLocString(loc)
+	if err != nil {
+		return ChainSpec{}, err
+	}
+
+	// Check location prefix (LocPrefix).
+	switch prefix {
+	case FileLoc:
+		if suffix == "" {
+			suffix = defaultChainSpecFile
+		}
+
+		return ReadSpecFile(suffix)
+
+	case TrackerLoc:
+		// Obtain genesis hash from hex string.
+		hash, err := cipher.SHA256FromHex(suffix)
+		if err != nil {
+			return ChainSpec{}, fmt.Errorf("invalid genesis hash provided '%s': %w", loc, err)
+		}
+
+		// Obtain spec from tracker.
+		signedChainSpec, err := tracker.SpecByGenesisHash(ctx, hash)
+		if err != nil {
+			return ChainSpec{}, fmt.Errorf("chain spec not of genesis hash not found in tracker: %w", err)
+		}
+
+		// Verify again (no harm in doing it twice).
+		if err := signedChainSpec.Verify(); err != nil {
+			return ChainSpec{}, err
+		}
+
+		return signedChainSpec.Spec, nil
+
+	default:
+		return ChainSpec{}, fmt.Errorf("%w '%s'", ErrInvalidLocPrefix, prefix)
+	}
+}
+
+func splitLocString(loc string) (prefix LocPrefix, suffix string, err error) {
+	loc = strings.TrimSpace(loc)
+	if loc == "" {
+		return "", "", ErrEmptySpec
+	}
+
+	locParts := strings.SplitN(loc, ":", 2)
+
+	switch len(locParts) {
+	case 1:
+		locParts = append([]string{string(TrackerLoc)}, locParts...)
+	case 2:
+		// continue
+	default:
+		panic("internal error: Locate() should never return >2 location parts")
+	}
+
+	return LocPrefix(locParts[0]), locParts[1], nil
+}

--- a/src/cx/cxspec/locate_test.go
+++ b/src/cx/cxspec/locate_test.go
@@ -1,0 +1,66 @@
+package cxspec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLocate(t *testing.T) {
+	t.Run("split_loc_string", func(t *testing.T) {
+		type TestCase struct {
+			name string // test name
+			in string   // test input
+
+			// expected outputs
+			prefix   LocPrefix
+			suffix   string
+			hasErr   bool
+			hasPanic bool
+		}
+
+		cases := []TestCase{
+			{
+				name: "0_parts",
+				in: "",
+				hasErr: true,
+			},
+			{
+				name: "1_parts",
+				in: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+				prefix: TrackerLoc,
+				suffix: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			},
+			{
+				name: "2_parts",
+				in: fmt.Sprintf("%s:%s", TrackerLoc, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+				prefix: TrackerLoc,
+				suffix: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			},
+			{
+				name: "2_parts",
+				in: fmt.Sprintf("%s:%s", FileLoc, `this\:/is/a\:/test/file.json`),
+				prefix: FileLoc,
+				suffix: `this\:/is/a\:/test/file.json`,
+			},
+		}
+
+		for _, c := range cases {
+			c := c
+
+			t.Run(c.name, func(t *testing.T) {
+				prefix, suffix, err := splitLocString(c.in)
+
+				if c.hasErr {
+					assert.Error(t, err)
+					return
+				}
+
+				assert.Equal(t, c.prefix, prefix)
+				assert.Equal(t, c.suffix, suffix)
+				assert.NoError(t, err)
+			})
+		}
+	})
+}


### PR DESCRIPTION
Fixes #24

Changes:
- Implement `cxspec.Locate` function to allow us to grab spec file from different location types (e.g. local filesystem and cx tracker).

Does this change need to mentioned in CHANGELOG.md?
> Yes
